### PR TITLE
fix(social-count): use tabular-numbers

### DIFF
--- a/src/gh-styles.css
+++ b/src/gh-styles.css
@@ -214,6 +214,7 @@ svg:not(:root) {
   border-top-right-radius: 6px;
   border-bottom-right-radius: 6px;
   box-shadow: var(--color-shadow-small), var(--color-shadow-highlight);
+  font-variant-numeric: tabular-nums;
 }
 
 .btn {
@@ -264,9 +265,9 @@ svg:not(:root) {
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Arial,
-    Noto Sans, Noto Sans CJK SC, sans-serif, Apple Color Emoji,
-    Segoe UI Emoji, Noto Color Emoji;
+  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Arial, Noto Sans,
+    Noto Sans CJK SC, sans-serif, Apple Color Emoji, Segoe UI Emoji,
+    Noto Color Emoji;
   line-height: 1.5;
   --color-text-primary: #24292e;
   --color-text-tertiary: #6a737d;


### PR DESCRIPTION
This makes sure all number contains the same width size, which avoids the number box length looking jarring. With this change, the start box looks more consistent and visually pleasant once its width doesn't change except when really necessary. 